### PR TITLE
update MariaDB to 12.3.2 safely

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       - app_network
 
   db:
-    image: mariadb:12.2.2
+    image: mariadb:12.3.2
     container_name: symfony_db_prod_appli_web_gestion_ticket
     restart: always
     environment:
@@ -47,6 +47,8 @@ services:
       MYSQL_DATABASE: ${DB_NAME}
       MYSQL_USER: ${DB_USER}
       MYSQL_PASSWORD: ${DB_PASSWORD}
+      # L'image officielle sauvegarde les tables système puis exécute mariadb-upgrade lors d'un changement de version.
+      MARIADB_AUTO_UPGRADE: "1"
     volumes:
       - db_data:/var/lib/mysql
     command: >


### PR DESCRIPTION
## Modifications

- met à jour MariaDB de 12.2.2 vers 12.3.2 ;
- active la mise à niveau automatique gérée par l’image officielle MariaDB.

## Vérifications

- démarrage d’un volume jetable sous MariaDB 12.2.2 avec une table de contrôle ;
- redémarrage du même volume sous MariaDB 12.3.2 ;
- sauvegarde des tables système et `mariadb-upgrade` exécutés avec succès ;
- donnée de contrôle conservée et `CHECK TABLE` valide ;
- configuration Docker Compose valide.

Aucun déploiement n’est exécuté par cette PR.
