### PR TITLE
upgrade MongoDB through the 8.0 release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@
 - Un déploiement normal doit préserver les volumes MariaDB, MongoDB, `public/ticket_image` et le fichier d'environnement de la cible.
 - Les secrets restent dans l'environnement sécurisé ou les secrets GitHub et ne doivent jamais entrer dans le dépôt.
 - Les migrations de MariaDB ou MongoDB exigent une sauvegarde vérifiée, un essai sur un volume jetable et une procédure de retour arrière.
+- MongoDB est fixé à `8.0.28`, palier obligatoire avant MongoDB 8.2. Une future montée vers 8.2 exige d'abord une période de validation sous 8.0 avec la FCV à `8.0`.
 
 ## Maintenance des dépendances
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,7 @@ services:
       - app_network
 
   mongodb:
-    image: mongo:7.0
+    image: mongo:8.0.28
     container_name: mongo_prod_appli_web_gestion_ticket
     restart: always
     volumes:


### PR DESCRIPTION
## Modifications

- met à jour MongoDB 7.0 vers la version exacte 8.0.28 ;
- documente ce palier obligatoire avant une future montée vers MongoDB 8.2.

## Pourquoi

La PR Dependabot proposait un saut direct de 7.0 à 8.2, qui ne respecte pas le chemin de mise à niveau MongoDB. La version 8.0 est le palier sûr requis.

## Vérifications

- création d’une donnée de contrôle sous MongoDB 7.0.40 ;
- démarrage du même volume sous MongoDB 8.0.28 ;
- donnée conservée et lisible ;
- passage de la FCV de 7.0 à 8.0 réussi ;
- redémarrage propre sous MongoDB 8.0.28 avec donnée et FCV conservées ;
- configuration Docker Compose valide.

Aucun déploiement n’est exécuté par cette PR.
